### PR TITLE
Migrate Solana swap program to Atomiq v2 parity

### DIFF
--- a/MIGRATION_V2.md
+++ b/MIGRATION_V2.md
@@ -1,0 +1,184 @@
+# Atomiq V2 Solana Migration
+
+This document summarizes the migration of the legacy Solana swap program to the Atomiq v2 model, aligned with:
+
+- Starknet v2: `/tmp/atomiq-v2-refs/atomiq-contracts-starknet`
+- EVM v2: `/tmp/atomiq-v2-refs/atomiq-contracts-evm`
+
+## Scope
+
+Migration was applied to the Solana Anchor program in `swaps/programs/swap-program`, plus supporting test and local-validator harness updates.
+
+## Parity Mapping
+
+### 1) Escrow state and lifecycle
+
+Added v2 lifecycle and routing metadata to `EscrowState`:
+
+- `lifecycle_state` (`NotCommitted`, `Committed`, `Claimed`, `Refunded`)
+- `init_slot`, `finish_slot`
+- `escrow_hash`
+- `claim_handler`, `refund_handler`
+- `success_action_commitment`
+
+Files:
+
+- `swaps/programs/swap-program/src/state.rs`
+- `swaps/programs/swap-program/src/enums.rs`
+
+### 2) V2 events
+
+Added v2-aligned events:
+
+- `EscrowInitializeEvent`
+- `EscrowClaimEvent`
+- `EscrowRefundEvent`
+- `EscrowExecutionErrorEvent`
+
+Legacy events were retained for backwards compatibility with existing Solana tests and integrations.
+
+Files:
+
+- `swaps/programs/swap-program/src/events.rs`
+
+### 3) V2 error surface
+
+Added v2 state/handler/commitment errors:
+
+- `EscrowAlreadyCommitted`
+- `EscrowNotCommitted`
+- `EscrowHashMismatch`
+- `InvalidClaimHandler`
+- `InvalidRefundHandler`
+- `InvalidSuccessActionCommitment`
+
+File:
+
+- `swaps/programs/swap-program/src/errors.rs`
+
+### 4) Initialize parity
+
+Added v2 initialize entrypoints:
+
+- `initialize(...)` (non-pay-in)
+- `initialize_pay_in(...)`
+
+Added initialization routing metadata and deterministic escrow hash computation.
+
+Files:
+
+- `swaps/programs/swap-program/src/lib.rs`
+- `swaps/programs/swap-program/src/ixs/initialize.rs`
+
+### 5) Claim parity
+
+Added v2 claim entrypoints:
+
+- `claim(...)`
+- `claim_pay_out(...)`
+- `claim_with_success_action(...)`
+- `claim_with_success_action_pay_out(...)`
+
+Added lifecycle and handler validation before claim execution.
+Added witness result propagation from claim verification into v2 claim event.
+
+Important v2 guard:
+
+- Plain `claim*` now rejects non-zero `success_action_commitment`.
+- `claim_with_success_action*` requires exact commitment match.
+
+Files:
+
+- `swaps/programs/swap-program/src/lib.rs`
+- `swaps/programs/swap-program/src/ixs/claim.rs`
+
+### 6) Refund parity
+
+Added v2 refund entrypoints:
+
+- `refund(...)`
+- `refund_pay_in(...)`
+- `cooperative_refund(...)`
+- `cooperative_refund_pay_in(...)`
+
+Added lifecycle and refund-handler checks before refund execution.
+
+Files:
+
+- `swaps/programs/swap-program/src/lib.rs`
+
+## Solana-Specific Adaptations
+
+### Handler representation
+
+EVM/Starknet v2 use handler contract addresses. Solana migration maps handlers to enums:
+
+- `ClaimHandlerType` <- `SwapType` mapping
+- `RefundHandlerType::Timelock`
+
+This preserves routing semantics while fitting a single-program Solana model.
+
+### Account model / PDA behavior
+
+State transitions are enforced in PDA-backed `EscrowState` and account constraints (`#[derive(Accounts)]`) rather than by external contract dispatch.
+
+### Compute and stack constraints
+
+Anchor account stack pressure fixes were required to avoid runtime `ProgramFailedToComplete` in heavy contexts:
+
+- `Deposit.user_data` boxed
+- Several `InitializePayIn` and optional `Initialize` accounts boxed
+
+File:
+
+- `swaps/programs/swap-program/src/instructions.rs`
+
+## Test and Local Harness Changes
+
+### Mocked BTC relay wiring
+
+To preserve chain-claim/refund behavior in tests, local validator genesis now preloads mocked `btc_relay`:
+
+- `swaps/Anchor.toml` adds `[[test.genesis]]`
+- `swaps/tests/btc_relay.json` metadata address updated to the mocked relay id
+
+### Sequential deterministic runner
+
+Added `swaps/tests/run-all.sh` and switched Anchor script to `bash ./tests/run-all.sh`.
+This avoids accidental concurrent test-file execution via command-token parsing.
+
+### Stability fixes
+
+- Reduced in-file parallelism default (`ParalelizedTest`) from `10` to `2`
+- Explicit `"confirmed"` confirmation in selected test helpers
+- Retry wrapper for `getTransaction()` in refund event assertions
+
+### New v2 regression coverage
+
+Added `swaps/tests/instructions/v2.ts`:
+
+- verifies plain `claim` is rejected when success-action commitment is set
+- verifies `claimWithSuccessAction` succeeds when commitment matches
+
+## Known Differences / Follow-up
+
+1. `success_action_commitment` validation is implemented, but no Solana-side execution contract CPI flow is currently wired.  
+2. `EscrowExecutionErrorEvent` type exists for v2 event parity but is not emitted yet because execution action dispatch is not implemented.
+
+## Validation Summary
+
+Validated with `anchor build` and instruction test suites including:
+
+- `deposit.ts`
+- `withdraw.ts`
+- `initialize.ts`
+- `claim.ts`
+- `v2.ts`
+- `refund.ts`
+
+Final full-run command (local):
+
+```bash
+cd swaps
+COPYFILE_DISABLE=1 anchor test
+```

--- a/btcrelay/Anchor.toml
+++ b/btcrelay/Anchor.toml
@@ -12,8 +12,8 @@ btc_relay = "3KHSHFpEK6bsjg3bqcxQ9qssJYtRCMi2S9TYVe4q6CQc"
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "mainnet"
-wallet = "~/mainnet.key"
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/swaps/Anchor.toml
+++ b/swaps/Anchor.toml
@@ -11,8 +11,15 @@ swap_program = "4hfUykhqmD7ZRvNh1HuzVKEY7ToENixtdUKZspNDCrEM"
 url = "https://anchor.projectserum.com"
 
 [provider]
-cluster = "mainnet"
-wallet = "~/mainnet.key"
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[test]
+startup_wait = 20000
+
+[[test.genesis]]
+address = "3KHSHFpEK6bsjg3bqcxQ9qssJYtRCMi2S9TYVe4q6CQc"
+program = "../btcrelay/target/deploy/btc_relay.so"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/instructions/*.ts"
+test = "bash ./tests/run-all.sh"

--- a/swaps/programs/swap-program/src/enums.rs
+++ b/swaps/programs/swap-program/src/enums.rs
@@ -9,3 +9,38 @@ pub enum SwapType {
     ChainTxhash = 3
 }
 pub const SWAP_TYPE_COUNT: usize = 4;
+
+#[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ClaimHandlerType {
+    Hashlock = 0,
+    BitcoinOutput = 1,
+    BitcoinNoncedOutput = 2,
+    BitcoinTxid = 3,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RefundHandlerType {
+    Timelock = 0,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EscrowLifecycleState {
+    NotCommitted = 0,
+    Committed = 1,
+    Claimed = 2,
+    Refunded = 3,
+}
+
+impl From<SwapType> for ClaimHandlerType {
+    fn from(value: SwapType) -> Self {
+        match value {
+            SwapType::Htlc => ClaimHandlerType::Hashlock,
+            SwapType::Chain => ClaimHandlerType::BitcoinOutput,
+            SwapType::ChainNonced => ClaimHandlerType::BitcoinNoncedOutput,
+            SwapType::ChainTxhash => ClaimHandlerType::BitcoinTxid,
+        }
+    }
+}

--- a/swaps/programs/swap-program/src/errors.rs
+++ b/swaps/programs/swap-program/src/errors.rs
@@ -65,4 +65,17 @@ pub enum SwapErrorCode {
     InvalidSwapDataPayIn,
     #[msg("Invalid swap data: nonce")]
     InvalidSwapDataNonce,
+
+    #[msg("Escrow state: already committed")]
+    EscrowAlreadyCommitted,
+    #[msg("Escrow state: not committed")]
+    EscrowNotCommitted,
+    #[msg("Escrow hash mismatch")]
+    EscrowHashMismatch,
+    #[msg("Invalid claim handler")]
+    InvalidClaimHandler,
+    #[msg("Invalid refund handler")]
+    InvalidRefundHandler,
+    #[msg("Invalid success action commitment")]
+    InvalidSuccessActionCommitment,
 }

--- a/swaps/programs/swap-program/src/events.rs
+++ b/swaps/programs/swap-program/src/events.rs
@@ -1,5 +1,5 @@
 use anchor_lang::prelude::*;
-use crate::SwapType;
+use crate::{SwapType, ClaimHandlerType, RefundHandlerType};
 
 #[event]
 pub struct InitializeEvent {
@@ -21,4 +21,37 @@ pub struct ClaimEvent {
     pub hash: [u8; 32],
     pub secret: [u8; 32],
     pub sequence: u64
+}
+
+#[event]
+pub struct EscrowInitializeEvent {
+    pub offerer: Pubkey,
+    pub claimer: Pubkey,
+    pub escrow_hash: [u8; 32],
+    pub claim_handler: ClaimHandlerType,
+    pub refund_handler: RefundHandlerType,
+}
+
+#[event]
+pub struct EscrowClaimEvent {
+    pub offerer: Pubkey,
+    pub claimer: Pubkey,
+    pub escrow_hash: [u8; 32],
+    pub claim_handler: ClaimHandlerType,
+    pub witness_result: [u8; 32],
+}
+
+#[event]
+pub struct EscrowRefundEvent {
+    pub offerer: Pubkey,
+    pub claimer: Pubkey,
+    pub escrow_hash: [u8; 32],
+    pub refund_handler: RefundHandlerType,
+    pub witness_result: [u8; 32],
+}
+
+#[event]
+pub struct EscrowExecutionErrorEvent {
+    pub escrow_hash: [u8; 32],
+    pub error: [u8; 32],
 }

--- a/swaps/programs/swap-program/src/instructions.rs
+++ b/swaps/programs/swap-program/src/instructions.rs
@@ -24,7 +24,7 @@ pub struct Deposit<'info> {
         payer = signer,
         space = UserAccount::SPACE
     )]
-    pub user_data: Account<'info, UserAccount>,
+    pub user_data: Box<Account<'info, UserAccount>>,
 
     //Account holding the tokens
     #[account(
@@ -109,7 +109,7 @@ pub struct InitializePayIn<'info> {
          constraint = offerer_ata.amount >= swap_data.amount,
          token::mint = mint
     )]
-    pub offerer_ata: Account<'info, TokenAccount>,
+    pub offerer_ata: Box<Account<'info, TokenAccount>>,
 
     //Data storage account
     #[account(
@@ -132,7 +132,7 @@ pub struct InitializePayIn<'info> {
         token::mint = mint,
         token::authority = vault_authority,
     )]
-    pub vault: Account<'info, TokenAccount>,
+    pub vault: Box<Account<'info, TokenAccount>>,
 
     /// CHECK: This account is not being read from, it is only an authority for the contract token vaults
     #[account(
@@ -142,7 +142,7 @@ pub struct InitializePayIn<'info> {
     pub vault_authority: AccountInfo<'info>,
 
     //Required data
-    pub mint: Account<'info, Mint>,
+    pub mint: Box<Account<'info, Mint>>,
     pub system_program: Program<'info, System>,
     pub token_program: Program<'info, Token>,
     
@@ -153,7 +153,7 @@ pub struct InitializePayIn<'info> {
         seeds = [USER_DATA_SEED, claimer.key.as_ref(), mint.to_account_info().key.as_ref()],
         bump = claimer_user_data.bump
     )]
-    pub claimer_user_data: Option<Account<'info, UserAccount>>,
+    pub claimer_user_data: Option<Box<Account<'info, UserAccount>>>,
 
     ////////////////////////////////////////
     //For pay out
@@ -161,7 +161,7 @@ pub struct InitializePayIn<'info> {
     #[account(
         token::mint = mint
     )]
-    pub claimer_ata: Option<Account<'info, TokenAccount>>,
+    pub claimer_ata: Option<Box<Account<'info, TokenAccount>>>,
 }
 
 #[derive(Accounts)]
@@ -205,7 +205,7 @@ pub struct Initialize<'info> {
         seeds = [USER_DATA_SEED, claimer.key.as_ref(), mint.to_account_info().key.as_ref()],
         bump = claimer_user_data.bump
     )]
-    pub claimer_user_data: Option<Account<'info, UserAccount>>,
+    pub claimer_user_data: Option<Box<Account<'info, UserAccount>>>,
     
     ////////////////////////////////////////
     //For pay out
@@ -213,7 +213,7 @@ pub struct Initialize<'info> {
     #[account(
         token::mint = mint
     )]
-    pub claimer_ata: Option<Account<'info, TokenAccount>>
+    pub claimer_ata: Option<Box<Account<'info, TokenAccount>>>
 }
 
 #[derive(Accounts)]

--- a/swaps/programs/swap-program/src/ixs/claim.rs
+++ b/swaps/programs/swap-program/src/ixs/claim.rs
@@ -13,7 +13,7 @@ use crate::events::*;
 use crate::structs::*;
 
 //Processes & checks the claim data - uses data from data_account if provided, otherwise uses data passed in secret param, emits ClaimEvent, throws on failure
-pub fn process_claim(signer: &Signer, swap_data: &SwapData, ix_sysvar: &AccountInfo, data_account: &mut Option<UncheckedAccount>, secret: &[u8]) -> Result<()> {
+pub fn process_claim(signer: &Signer, swap_data: &SwapData, ix_sysvar: &AccountInfo, data_account: &mut Option<UncheckedAccount>, secret: &[u8]) -> Result<[u8; 32]> {
 
     let event_secret = match data_account {
         Some(data_acc) => {
@@ -51,7 +51,7 @@ pub fn process_claim(signer: &Signer, swap_data: &SwapData, ix_sysvar: &AccountI
         sequence: swap_data.sequence
     });
     
-    Ok(())
+    Ok(event_secret)
 }
 
 //Verifies if the claim is claimable by the claimer, provided the secret data (tx data or preimage for HTLC), returns the preimage (for HTLC, or TXHASH for PTLC)

--- a/swaps/programs/swap-program/src/ixs/initialize.rs
+++ b/swaps/programs/swap-program/src/ixs/initialize.rs
@@ -1,6 +1,7 @@
 use anchor_lang::{
     prelude::*, 
-    solana_program::clock
+    solana_program::clock,
+    solana_program::hash,
 };
 use anchor_spl::token::{
     Mint,
@@ -17,18 +18,45 @@ fn now_ts() -> Result<u64> {
     Ok(clock::Clock::get().unwrap().unix_timestamp.try_into().unwrap())
 }
 
+fn now_slot() -> Result<u64> {
+    Ok(clock::Clock::get().unwrap().slot)
+}
+
+fn compute_escrow_hash(
+    offerer: &Pubkey,
+    claimer: &Pubkey,
+    mint: &Pubkey,
+    swap_data: &SwapData,
+    security_deposit: u64,
+    claimer_bounty: u64,
+    success_action_commitment: &[u8; 32],
+) -> Result<[u8; 32]> {
+    let mut payload = Vec::with_capacity(256);
+    payload.extend_from_slice(offerer.as_ref());
+    payload.extend_from_slice(claimer.as_ref());
+    payload.extend_from_slice(mint.as_ref());
+    payload.extend_from_slice(&swap_data.try_to_vec()?);
+    payload.extend_from_slice(&security_deposit.to_le_bytes());
+    payload.extend_from_slice(&claimer_bounty.to_le_bytes());
+    payload.extend_from_slice(success_action_commitment);
+    Ok(hash::hash(&payload).to_bytes())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn process_initialize(
     escrow_state: &mut Account<EscrowState>,
     offerer: &AccountInfo,
     claimer: &AccountInfo,
-    claimer_ata: &Option<Account<TokenAccount>>,
+    claimer_ata: Option<&Account<TokenAccount>>,
     mint: &Account<Mint>,
 
     swap_data: &SwapData,
     
     txo_hash: [u8; 32], //Only for on-chain,
-    auth_expiry: u64
+    auth_expiry: u64,
+    security_deposit: u64,
+    claimer_bounty: u64,
+    success_action_commitment: [u8; 32],
 ) -> Result<()> {
     require!(
         auth_expiry > now_ts()?,
@@ -47,16 +75,38 @@ pub fn process_initialize(
         );
     }
 
+    require!(
+        escrow_state.lifecycle_state == EscrowLifecycleState::NotCommitted,
+        SwapErrorCode::EscrowAlreadyCommitted
+    );
+
     escrow_state.data = swap_data.clone();
 
     escrow_state.offerer = *offerer.key;
     escrow_state.claimer = *claimer.to_account_info().key;
 
     if swap_data.pay_out {
-        let claimer_ata = claimer_ata.as_ref().expect("Claimer ATA not provided for pay_out=true swap");
+        let claimer_ata = claimer_ata.expect("Claimer ATA not provided for pay_out=true swap");
         escrow_state.claimer_ata = *claimer_ata.to_account_info().key;
     }
     escrow_state.mint = *mint.to_account_info().key;
+    escrow_state.security_deposit = security_deposit;
+    escrow_state.claimer_bounty = claimer_bounty;
+    escrow_state.claim_handler = swap_data.kind.into();
+    escrow_state.refund_handler = RefundHandlerType::Timelock;
+    escrow_state.success_action_commitment = success_action_commitment;
+    escrow_state.lifecycle_state = EscrowLifecycleState::Committed;
+    escrow_state.init_slot = now_slot()?;
+    escrow_state.finish_slot = 0;
+    escrow_state.escrow_hash = compute_escrow_hash(
+        offerer.key,
+        claimer.key,
+        mint.to_account_info().key,
+        swap_data,
+        security_deposit,
+        claimer_bounty,
+        &success_action_commitment,
+    )?;
 
     emit!(InitializeEvent {
         hash: swap_data.hash,
@@ -64,6 +114,14 @@ pub fn process_initialize(
         nonce: swap_data.nonce,
         kind: swap_data.kind,
         sequence: swap_data.sequence
+    });
+
+    emit!(EscrowInitializeEvent {
+        offerer: escrow_state.offerer,
+        claimer: escrow_state.claimer,
+        escrow_hash: escrow_state.escrow_hash,
+        claim_handler: escrow_state.claim_handler,
+        refund_handler: escrow_state.refund_handler,
     });
 
     Ok(())

--- a/swaps/programs/swap-program/src/lib.rs
+++ b/swaps/programs/swap-program/src/lib.rs
@@ -1,6 +1,7 @@
 use anchor_lang::{
     prelude::*, 
     solana_program::clock, 
+    solana_program::hash,
     solana_program::sysvar::instructions::ID as IX_ID,
     system_program
 };
@@ -12,6 +13,7 @@ use std::cmp;
 
 use enums::*;
 use errors::*;
+use events::*;
 use state::*;
 use instructions::*;
 use structs::*;
@@ -30,6 +32,10 @@ declare_id!("4hfUykhqmD7ZRvNh1HuzVKEY7ToENixtdUKZspNDCrEM");
 
 pub fn now_ts() -> Result<u64> {
     Ok(clock::Clock::get().unwrap().unix_timestamp.try_into().unwrap())
+}
+
+pub fn now_slot() -> Result<u64> {
+    Ok(clock::Clock::get().unwrap().slot)
 }
 
 const AUTHORITY_SEED: &[u8] = b"authority";
@@ -53,7 +59,7 @@ pub mod swap_program {
             ctx.accounts.get_transfer_to_vault_context(),
             amount,
         )?;
-        
+
         ctx.accounts.user_data.bump = ctx.bumps.user_data;
         ctx.accounts.user_data.amount += amount;
 
@@ -98,11 +104,14 @@ pub mod swap_program {
             &mut ctx.accounts.escrow_state,
             &ctx.accounts.offerer.to_account_info(),
             &ctx.accounts.claimer,
-            &ctx.accounts.claimer_ata,
+            ctx.accounts.claimer_ata.as_deref(),
             &ctx.accounts.mint,
             &swap_data,
             txo_hash,
             auth_expiry,
+            0,
+            0,
+            [0; 32],
         )?;
 
         ctx.accounts.escrow_state.offerer_ata = *ctx.accounts.offerer_ata.to_account_info().key;
@@ -139,11 +148,14 @@ pub mod swap_program {
             &mut ctx.accounts.escrow_state,
             &ctx.accounts.offerer.to_account_info(),
             &ctx.accounts.claimer,
-            &ctx.accounts.claimer_ata,
+            ctx.accounts.claimer_ata.as_deref(),
             &ctx.accounts.mint,
             &swap_data,
             txo_hash,
             auth_expiry,
+            security_deposit,
+            claimer_bounty,
+            [0; 32],
         )?;
 
         //We can calculate only the maximum of the two, not a sum,
@@ -166,10 +178,90 @@ pub mod swap_program {
             system_program::transfer(cpi_ctx, difference)?;
         }
         
-        ctx.accounts.escrow_state.security_deposit = security_deposit;
-        ctx.accounts.escrow_state.claimer_bounty = claimer_bounty;
+        ctx.accounts.offerer_user_data.amount -= swap_data.amount;
+
+        Ok(())
+    }
+
+    //V2-compatible initialize entrypoint (non-pay_in).
+    pub fn initialize(
+        ctx: Context<Initialize>,
+        swap_data: SwapData,
+        security_deposit: u64,
+        claimer_bounty: u64,
+        txo_hash: [u8; 32],
+        auth_expiry: u64,
+        success_action_commitment: [u8; 32],
+    ) -> Result<()> {
+        require!(
+            !swap_data.pay_in,
+            SwapErrorCode::InvalidSwapDataPayIn
+        );
+
+        ixs::initialize::process_initialize(
+            &mut ctx.accounts.escrow_state,
+            &ctx.accounts.offerer.to_account_info(),
+            &ctx.accounts.claimer,
+            ctx.accounts.claimer_ata.as_deref(),
+            &ctx.accounts.mint,
+            &swap_data,
+            txo_hash,
+            auth_expiry,
+            security_deposit,
+            claimer_bounty,
+            success_action_commitment,
+        )?;
+
+        let required_lamports = cmp::max(security_deposit, claimer_bounty);
+        let dst_starting_lamports = ctx.accounts.escrow_state.to_account_info().lamports();
+        if dst_starting_lamports < required_lamports {
+            let difference = required_lamports - dst_starting_lamports;
+            let cpi_program = ctx.accounts.system_program.to_account_info();
+            let transfer_lamports_instruction = system_program::Transfer {
+                from: ctx.accounts.claimer.to_account_info(),
+                to: ctx.accounts.escrow_state.to_account_info(),
+            };
+            let cpi_ctx = CpiContext::new(cpi_program, transfer_lamports_instruction);
+            system_program::transfer(cpi_ctx, difference)?;
+        }
 
         ctx.accounts.offerer_user_data.amount -= swap_data.amount;
+
+        Ok(())
+    }
+
+    //V2-compatible initialize entrypoint (pay_in).
+    pub fn initialize_pay_in(
+        ctx: Context<InitializePayIn>,
+        swap_data: SwapData,
+        txo_hash: [u8; 32],
+        auth_expiry: u64,
+        success_action_commitment: [u8; 32],
+    ) -> Result<()> {
+        require!(
+            swap_data.pay_in,
+            SwapErrorCode::InvalidSwapDataPayIn
+        );
+
+        ixs::initialize::process_initialize(
+            &mut ctx.accounts.escrow_state,
+            &ctx.accounts.offerer.to_account_info(),
+            &ctx.accounts.claimer,
+            ctx.accounts.claimer_ata.as_deref(),
+            &ctx.accounts.mint,
+            &swap_data,
+            txo_hash,
+            auth_expiry,
+            0,
+            0,
+            success_action_commitment,
+        )?;
+
+        ctx.accounts.escrow_state.offerer_ata = *ctx.accounts.offerer_ata.to_account_info().key;
+        token::transfer(
+            ctx.accounts.get_transfer_to_pda_context(),
+            ctx.accounts.escrow_state.data.amount,
+        )?;
 
         Ok(())
     }
@@ -177,7 +269,30 @@ pub mod swap_program {
     //Refund back to offerer once enough time has passed,
     // or by providing a "refund" message signed by claimer
     pub fn offerer_refund(ctx: Context<Refund>, auth_expiry: u64) -> Result<()> {
+        require!(
+            ctx.accounts.escrow_state.lifecycle_state == EscrowLifecycleState::Committed,
+            SwapErrorCode::EscrowNotCommitted
+        );
+        require!(
+            ctx.accounts.escrow_state.refund_handler == RefundHandlerType::Timelock,
+            SwapErrorCode::InvalidRefundHandler
+        );
+
         let is_cooperative = ixs::refund::process_refund(auth_expiry, &ctx.accounts.escrow_state, &ctx.accounts.ix_sysvar, &mut ctx.accounts.claimer_user_data)?;
+        ctx.accounts.escrow_state.lifecycle_state = EscrowLifecycleState::Refunded;
+        ctx.accounts.escrow_state.finish_slot = now_slot()?;
+
+        emit!(EscrowRefundEvent {
+            offerer: ctx.accounts.escrow_state.offerer,
+            claimer: ctx.accounts.escrow_state.claimer,
+            escrow_hash: ctx.accounts.escrow_state.escrow_hash,
+            refund_handler: ctx.accounts.escrow_state.refund_handler,
+            witness_result: if is_cooperative {
+                hash::hash(&auth_expiry.to_le_bytes()).to_bytes()
+            } else {
+                ctx.accounts.escrow_state.data.hash
+            },
+        });
 
         //Refund to internal wallet
         ctx.accounts.offerer_user_data.amount += ctx.accounts.escrow_state.data.amount;
@@ -190,7 +305,30 @@ pub mod swap_program {
     //Refund back to offerer once enough time has passed,
     // or by providing a "refund" message signed by claimer
     pub fn offerer_refund_pay_in(ctx: Context<RefundPayIn>, auth_expiry: u64) -> Result<()> {
+        require!(
+            ctx.accounts.escrow_state.lifecycle_state == EscrowLifecycleState::Committed,
+            SwapErrorCode::EscrowNotCommitted
+        );
+        require!(
+            ctx.accounts.escrow_state.refund_handler == RefundHandlerType::Timelock,
+            SwapErrorCode::InvalidRefundHandler
+        );
+
         let is_cooperative = ixs::refund::process_refund(auth_expiry, &ctx.accounts.escrow_state, &ctx.accounts.ix_sysvar, &mut ctx.accounts.claimer_user_data)?;
+        ctx.accounts.escrow_state.lifecycle_state = EscrowLifecycleState::Refunded;
+        ctx.accounts.escrow_state.finish_slot = now_slot()?;
+
+        emit!(EscrowRefundEvent {
+            offerer: ctx.accounts.escrow_state.offerer,
+            claimer: ctx.accounts.escrow_state.claimer,
+            escrow_hash: ctx.accounts.escrow_state.escrow_hash,
+            refund_handler: ctx.accounts.escrow_state.refund_handler,
+            witness_result: if is_cooperative {
+                hash::hash(&auth_expiry.to_le_bytes()).to_bytes()
+            } else {
+                ctx.accounts.escrow_state.data.hash
+            },
+        });
 
         //Refund in token to external wallet
         let authority_seeds = &[AUTHORITY_SEED, &[ctx.bumps.vault_authority]];
@@ -209,7 +347,26 @@ pub mod swap_program {
 
     //Claim the swap using the "secret", or data in the provided "data" account
     pub fn claimer_claim(ctx: Context<Claim>, secret: Vec<u8>) -> Result<()> {
-        ixs::claim::process_claim(&ctx.accounts.signer, &ctx.accounts.escrow_state.data, &ctx.accounts.ix_sysvar, &mut ctx.accounts.data, &secret)?;
+        require!(
+            ctx.accounts.escrow_state.lifecycle_state == EscrowLifecycleState::Committed,
+            SwapErrorCode::EscrowNotCommitted
+        );
+        require!(
+            ctx.accounts.escrow_state.claim_handler == ClaimHandlerType::from(ctx.accounts.escrow_state.data.kind),
+            SwapErrorCode::InvalidClaimHandler
+        );
+
+        let witness_result = ixs::claim::process_claim(&ctx.accounts.signer, &ctx.accounts.escrow_state.data, &ctx.accounts.ix_sysvar, &mut ctx.accounts.data, &secret)?;
+        ctx.accounts.escrow_state.lifecycle_state = EscrowLifecycleState::Claimed;
+        ctx.accounts.escrow_state.finish_slot = now_slot()?;
+
+        emit!(EscrowClaimEvent {
+            offerer: ctx.accounts.escrow_state.offerer,
+            claimer: ctx.accounts.escrow_state.claimer,
+            escrow_hash: ctx.accounts.escrow_state.escrow_hash,
+            claim_handler: ctx.accounts.escrow_state.claim_handler,
+            witness_result,
+        });
 
         let user_data = &mut ctx.accounts.claimer_user_data;
         user_data.amount += ctx.accounts.escrow_state.data.amount;
@@ -223,7 +380,26 @@ pub mod swap_program {
 
     //Claim the swap using the "secret", or data in the provided "data" account
     pub fn claimer_claim_pay_out(ctx: Context<ClaimPayOut>, secret: Vec<u8>) -> Result<()> {
-        ixs::claim::process_claim(&ctx.accounts.signer, &ctx.accounts.escrow_state.data, &ctx.accounts.ix_sysvar, &mut ctx.accounts.data, &secret)?;
+        require!(
+            ctx.accounts.escrow_state.lifecycle_state == EscrowLifecycleState::Committed,
+            SwapErrorCode::EscrowNotCommitted
+        );
+        require!(
+            ctx.accounts.escrow_state.claim_handler == ClaimHandlerType::from(ctx.accounts.escrow_state.data.kind),
+            SwapErrorCode::InvalidClaimHandler
+        );
+
+        let witness_result = ixs::claim::process_claim(&ctx.accounts.signer, &ctx.accounts.escrow_state.data, &ctx.accounts.ix_sysvar, &mut ctx.accounts.data, &secret)?;
+        ctx.accounts.escrow_state.lifecycle_state = EscrowLifecycleState::Claimed;
+        ctx.accounts.escrow_state.finish_slot = now_slot()?;
+
+        emit!(EscrowClaimEvent {
+            offerer: ctx.accounts.escrow_state.offerer,
+            claimer: ctx.accounts.escrow_state.claimer,
+            escrow_hash: ctx.accounts.escrow_state.escrow_hash,
+            claim_handler: ctx.accounts.escrow_state.claim_handler,
+            witness_result,
+        });
 
         let authority_seeds = &[AUTHORITY_SEED, &[ctx.bumps.vault_authority]];
 
@@ -237,6 +413,70 @@ pub mod swap_program {
         ixs::claim::pay_claimer_bounty(&ctx.accounts.signer, &ctx.accounts.initializer, &ctx.accounts.escrow_state)?;
 
         Ok(())
+    }
+
+    //V2-compatible claim entrypoint (non-pay_out).
+    pub fn claim(ctx: Context<Claim>, witness: Vec<u8>) -> Result<()> {
+        require!(
+            ctx.accounts.escrow_state.success_action_commitment == [0; 32],
+            SwapErrorCode::InvalidSuccessActionCommitment
+        );
+        claimer_claim(ctx, witness)
+    }
+
+    //V2-compatible claim entrypoint (pay_out).
+    pub fn claim_pay_out(ctx: Context<ClaimPayOut>, witness: Vec<u8>) -> Result<()> {
+        require!(
+            ctx.accounts.escrow_state.success_action_commitment == [0; 32],
+            SwapErrorCode::InvalidSuccessActionCommitment
+        );
+        claimer_claim_pay_out(ctx, witness)
+    }
+
+    //V2-compatible claim entrypoint with success action commitment (non-pay_out).
+    pub fn claim_with_success_action(
+        ctx: Context<Claim>,
+        witness: Vec<u8>,
+        success_action_commitment: [u8; 32],
+    ) -> Result<()> {
+        require!(
+            ctx.accounts.escrow_state.success_action_commitment == success_action_commitment,
+            SwapErrorCode::InvalidSuccessActionCommitment
+        );
+        claimer_claim(ctx, witness)
+    }
+
+    //V2-compatible claim entrypoint with success action commitment (pay_out).
+    pub fn claim_with_success_action_pay_out(
+        ctx: Context<ClaimPayOut>,
+        witness: Vec<u8>,
+        success_action_commitment: [u8; 32],
+    ) -> Result<()> {
+        require!(
+            ctx.accounts.escrow_state.success_action_commitment == success_action_commitment,
+            SwapErrorCode::InvalidSuccessActionCommitment
+        );
+        claimer_claim_pay_out(ctx, witness)
+    }
+
+    //V2-compatible refund entrypoint (timelock witness only, non-pay_in).
+    pub fn refund(ctx: Context<Refund>) -> Result<()> {
+        offerer_refund(ctx, 0)
+    }
+
+    //V2-compatible refund entrypoint (timelock witness only, pay_in).
+    pub fn refund_pay_in(ctx: Context<RefundPayIn>) -> Result<()> {
+        offerer_refund_pay_in(ctx, 0)
+    }
+
+    //V2-compatible cooperative refund entrypoint (non-pay_in).
+    pub fn cooperative_refund(ctx: Context<Refund>, auth_expiry: u64) -> Result<()> {
+        offerer_refund(ctx, auth_expiry)
+    }
+
+    //V2-compatible cooperative refund entrypoint (pay_in).
+    pub fn cooperative_refund_pay_in(ctx: Context<RefundPayIn>, auth_expiry: u64) -> Result<()> {
+        offerer_refund_pay_in(ctx, auth_expiry)
     }
 
     //Initializes the data account, by writting signer's key to it

--- a/swaps/programs/swap-program/src/state.rs
+++ b/swaps/programs/swap-program/src/state.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use crate::SWAP_TYPE_COUNT;
+use crate::enums::{ClaimHandlerType, EscrowLifecycleState, RefundHandlerType};
 use crate::structs::SwapData;
 
 //Swap contract between offerer and claimer
@@ -24,11 +25,21 @@ pub struct EscrowState {
     //Security deposit, paid out to offerer in case swap expires and needs to be refunded.
     //Used to cover transaction fee and compensate for time value of money locked up in the contract.
     //Alway paid as native Solana, in Lamports
-    pub security_deposit: u64
+    pub security_deposit: u64,
+
+    //V2 lifecycle and routing metadata.
+    pub lifecycle_state: EscrowLifecycleState,
+    pub init_slot: u64,
+    pub finish_slot: u64,
+    pub escrow_hash: [u8; 32],
+    pub claim_handler: ClaimHandlerType,
+    pub refund_handler: RefundHandlerType,
+    pub success_action_commitment: [u8; 32],
 }
 
 impl EscrowState {
-    pub const SPACE: usize = 8 + 1 + 2 + 8 + 192 + 8 + 8 + 1 + 1 + 8 + 8 + 8 + 1;
+    //Keep a conservative allocation to avoid layout drift issues.
+    pub const SPACE: usize = 8 + 384;
 }
 
 //PDA format for storing user's (LP node's) balance and reputation

--- a/swaps/tests/btc_relay.json
+++ b/swaps/tests/btc_relay.json
@@ -666,6 +666,6 @@
     }
   ],
   "metadata": {
-    "address": "De2dsY5K3DXBDNzKUjE6KguVP5JUhveKNpMVRmRkazff"
+    "address": "3KHSHFpEK6bsjg3bqcxQ9qssJYtRCMi2S9TYVe4q6CQc"
   }
 }

--- a/swaps/tests/instructions/claim.ts
+++ b/swaps/tests/instructions/claim.ts
@@ -689,7 +689,7 @@ async function verifyClaimInvariants(data: ClaimIXData, initialState: ClaimIniti
 
 }
 
-const parallelTest = new ParalelizedTest();
+const parallelTest = new ParalelizedTest(1);
 
 function runTestsWith(payIn: boolean, payOut: boolean, kind: SwapType, claimWithAccount: boolean) {
 

--- a/swaps/tests/instructions/deposit.ts
+++ b/swaps/tests/instructions/deposit.ts
@@ -75,7 +75,7 @@ async function execute(accounts: IXAccounts): Promise<{result: SignatureResult, 
     const signature = await provider.connection.sendTransaction(tx, [accounts.signer], {
         skipPreflight: true
     });
-    const result = await provider.connection.confirmTransaction(signature);
+    const result = await provider.connection.confirmTransaction(signature, "confirmed");
 
     return {
         result: result.value,

--- a/swaps/tests/instructions/refund.ts
+++ b/swaps/tests/instructions/refund.ts
@@ -20,6 +20,19 @@ const program = workspace.SwapProgram as Program<SwapProgram>;
 const provider: AnchorProvider = AnchorProvider.local();
 const eventParser = new EventParser(program.programId, program.coder);
 
+async function getTransactionWithRetry(signature: string, retries: number = 20, delayMs: number = 500): Promise<any> {
+    for (let i = 0; i < retries; i++) {
+        const tx = await provider.connection.getTransaction(signature, {
+            commitment: "confirmed"
+        });
+        if (tx != null) {
+            return tx;
+        }
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    return null;
+}
+
 type RefundIXData = RefundIXDataNotPayIn | RefundIXDataPayIn;
 type RefundIXDataNotPayIn = {
     params: RefundIXParams,
@@ -378,9 +391,8 @@ function runTestsWith(payIn: boolean, payOut: boolean, refundType: "signed" | "t
             assert(initialClaimerLamports+pdaLamports-securityDeposit===postClaimerLamports, "Invalid claimer lamport balance, expected: "+(initialClaimerLamports+pdaLamports-securityDeposit)+" got: "+postClaimerLamports);
         }
         //Check that event was emitted
-        const tx = await provider.connection.getTransaction(signature, {
-            commitment: "confirmed"
-        });
+        const tx = await getTransactionWithRetry(signature);
+        assert(tx!=null, "Transaction not found by signature: "+signature);
         
         const parsedEvents = eventParser.parseLogs(tx.meta.logMessages);
 

--- a/swaps/tests/instructions/v2.ts
+++ b/swaps/tests/instructions/v2.ts
@@ -1,0 +1,129 @@
+import { Keypair, SignatureResult, SYSVAR_INSTRUCTIONS_PUBKEY, Transaction } from "@solana/web3.js";
+import { AnchorProvider, Program, workspace } from "@coral-xyz/anchor";
+import { SwapProgram } from "../../target/types/swap_program";
+import { assert } from "chai";
+import { createHash, randomBytes } from "crypto";
+import { getInitializeDefaultDataNotPayIn, InitializeIXDataNotPayIn } from "../utils/escrowState";
+import { parseSwapProgramError, CombinedProgramErrorType } from "../utils/program";
+
+const program = workspace.SwapProgram as Program<SwapProgram>;
+const provider: AnchorProvider = AnchorProvider.local();
+
+async function initializeWithSuccessActionCommitment(
+    commitment: Buffer
+): Promise<{ init: InitializeIXDataNotPayIn; secret: Buffer; commitment: Buffer }> {
+    const secret = randomBytes(32);
+    const hash = createHash("sha256").update(secret).digest();
+
+    const init = await getInitializeDefaultDataNotPayIn(
+        false,
+        undefined,
+        undefined,
+        "htlc",
+        Math.floor(Date.now() / 1000) + 3600,
+        hash
+    );
+
+    const tx = await program.methods
+        .initialize(
+            {
+                ...init.params.swapData,
+                hash: Buffer.from(init.params.swapData.hash),
+            } as any,
+            init.params.securityDeposit,
+            init.params.claimerBounty,
+            Buffer.from(init.params.txoHash),
+            init.params.authExpiry,
+            commitment
+        )
+        .accounts({
+            claimer: init.accounts.claimer.publicKey,
+            offerer: init.accounts.offerer.publicKey,
+            offererUserData: init.accounts.offererUserData,
+            escrowState: init.accounts.escrowState,
+            mint: init.accounts.mint,
+            systemProgram: init.accounts.systemProgram,
+            claimerUserData: init.accounts.claimerUserData,
+            claimerAta: init.accounts.claimerAta,
+        })
+        .transaction();
+
+    tx.feePayer = init.accounts.claimer.publicKey;
+
+    const signature = await provider.connection.sendTransaction(tx, [init.accounts.claimer, init.accounts.offerer], {
+        skipPreflight: true,
+    });
+    const result = await provider.connection.confirmTransaction(signature, "confirmed");
+    assert(result.value.err == null, "initialize failed: " + JSON.stringify(result.value.err));
+
+    return {
+        init,
+        secret,
+        commitment,
+    };
+}
+
+async function executeClaim(
+    init: InitializeIXDataNotPayIn,
+    secret: Buffer,
+    commitment?: Buffer
+): Promise<{ result: SignatureResult; error: CombinedProgramErrorType }> {
+    const ix = commitment == null
+        ? await program.methods
+              .claim(secret)
+              .accounts({
+                  signer: init.accounts.claimer.publicKey,
+                  initializer: init.accounts.claimer.publicKey,
+                  escrowState: init.accounts.escrowState,
+                  ixSysvar: SYSVAR_INSTRUCTIONS_PUBKEY,
+                  claimerUserData: init.accounts.claimerUserData,
+                  data: null,
+              })
+              .instruction()
+        : await program.methods
+              .claimWithSuccessAction(secret, commitment)
+              .accounts({
+                  signer: init.accounts.claimer.publicKey,
+                  initializer: init.accounts.claimer.publicKey,
+                  escrowState: init.accounts.escrowState,
+                  ixSysvar: SYSVAR_INSTRUCTIONS_PUBKEY,
+                  claimerUserData: init.accounts.claimerUserData,
+                  data: null,
+              })
+              .instruction();
+
+    const tx = new Transaction();
+    tx.add(ix);
+    tx.feePayer = init.accounts.claimer.publicKey;
+
+    const signature = await provider.connection.sendTransaction(tx, [init.accounts.claimer as Keypair], {
+        skipPreflight: true,
+    });
+    const confirmed = await provider.connection.confirmTransaction(signature, "confirmed");
+
+    return {
+        result: confirmed.value,
+        error: parseSwapProgramError(0, confirmed.value.err),
+    };
+}
+
+describe("swap-program: V2 wrappers", () => {
+    it("rejects plain claim when success_action_commitment is set", async () => {
+        const commitment = randomBytes(32);
+        const { init, secret } = await initializeWithSuccessActionCommitment(commitment);
+
+        const { result, error } = await executeClaim(init, secret);
+
+        assert(result.err != null, "claim unexpectedly succeeded");
+        assert(error === "InvalidSuccessActionCommitment", "unexpected error: " + error);
+    });
+
+    it("accepts claimWithSuccessAction when commitment matches", async () => {
+        const commitment = randomBytes(32);
+        const { init, secret } = await initializeWithSuccessActionCommitment(commitment);
+
+        const { result, error } = await executeClaim(init, secret, commitment);
+
+        assert(result.err == null, "claimWithSuccessAction failed: " + error);
+    });
+});

--- a/swaps/tests/run-all.sh
+++ b/swaps/tests/run-all.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/instructions/deposit.ts
+yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/instructions/withdraw.ts
+yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/instructions/initialize.ts
+yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/instructions/claim.ts
+yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/instructions/v2.ts
+yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/instructions/refund.ts

--- a/swaps/tests/utils.ts
+++ b/swaps/tests/utils.ts
@@ -7,7 +7,7 @@ export class ParalelizedTest {
         fn: () => Promise<void>
     }[] = [];
 
-    constructor(maxParallelTests: number = 10) {
+    constructor(maxParallelTests: number = 2) {
         this.maxParallelTests = maxParallelTests;
     }
 

--- a/swaps/tests/utils/vault.ts
+++ b/swaps/tests/utils/vault.ts
@@ -39,7 +39,7 @@ export async function getInitializedVault(mintData: TokenMint, depositAmount: BN
     const signature = await provider.connection.sendTransaction(tx, [signer], {
         skipPreflight: true
     });
-    const result = await provider.connection.confirmTransaction(signature);
+    const result = await provider.connection.confirmTransaction(signature, "confirmed");
 
     assert(result.value.err==null, "getInitializedVault(): Transaction error: "+JSON.stringify(result.value.err, null, 4));
 


### PR DESCRIPTION
## Summary
- migrate Solana swap program lifecycle and interfaces to Atomiq v2 parity targets
- add v2-compatible wrappers and success-action commitment validation paths
- overhaul/stabilize test harness and add dedicated v2 wrapper coverage
- add migration parity notes and known differences in `MIGRATION_V2.md`

## Key changes
- Program migration (core v2):
  - `swaps/programs/swap-program/src/enums.rs`
  - `swaps/programs/swap-program/src/errors.rs`
  - `swaps/programs/swap-program/src/events.rs`
  - `swaps/programs/swap-program/src/instructions.rs`
  - `swaps/programs/swap-program/src/ixs/claim.rs`
  - `swaps/programs/swap-program/src/ixs/initialize.rs`
  - `swaps/programs/swap-program/src/lib.rs`
  - `swaps/programs/swap-program/src/state.rs`
- Test updates + new v2 tests:
  - `swaps/tests/instructions/v2.ts`
  - `swaps/tests/run-all.sh`
  - updates across `deposit.ts`, `refund.ts`, `utils.ts`, `utils/vault.ts`, `Anchor.toml`
- Docs:
  - `MIGRATION_V2.md`

## Validation
Full local suite executed with:
- `COPYFILE_DISABLE=1 anchor test`

Observed passing suites:
- `deposit.ts`: 12 passing
- `withdraw.ts`: 11 passing
- `initialize.ts`: 42 passing
- `claim.ts`: 480 passing
- `v2.ts`: 2 passing
- `refund.ts`: 118 passing

## Notes
- claim test matrix is serialized (`ParalelizedTest(1)`) to avoid flaky race conditions in long negative-path combinations while preserving coverage.
